### PR TITLE
Chapter 5 – Local Variables

### DIFF
--- a/docs/driver-manual.md
+++ b/docs/driver-manual.md
@@ -15,7 +15,7 @@ The compiled binary is at `bin/main.exe` (invoked as `./bin/main.exe` on Unix-li
 ## Usage
 
 ```
-./bin/main.exe [--lex | --parse | --tacky | --codegen] [-S] \
+./bin/main.exe [--lex | --parse | --validate | --tacky | --codegen] [-S] \
   [--dump-tokens[=<path>]] \
   [--dump-ast[=txt|dot|json] [--dump-ast-path=<path>]] \
   [--dump-tacky[=txt|json] [--dump-tacky-path=<path>]] \
@@ -26,6 +26,7 @@ The compiled binary is at `bin/main.exe` (invoked as `./bin/main.exe` on Unix-li
 
 - `--lex`: Run lexer only (no files written).
 - `--parse`: Run lexer + parser (no files written).
+- `--validate`: Run lexer + parser + semantic validation (no files written).
 - `--tacky`: Run up to TACKY IR generation (no files written).
 - `--codegen`: Run up to assembly IR generation (no emission).
 

--- a/examples/chapter_5/valid1.c
+++ b/examples/chapter_5/valid1.c
@@ -1,0 +1,6 @@
+int main(void) {
+  int a = 4;
+  int b;
+  b = a + 3;
+  return b;
+}

--- a/examples/chapter_5/valid2.c
+++ b/examples/chapter_5/valid2.c
@@ -1,0 +1,7 @@
+int main(void) {
+  int a = 1;
+  int b = 2;
+  (a = b + 5);
+  ;
+  return a;
+}

--- a/examples/chapter_5/valid3.c
+++ b/examples/chapter_5/valid3.c
@@ -1,0 +1,6 @@
+int main(void) {
+  int x;
+  int y = 7;
+  x = y = y + 1;
+  return x + y;
+}

--- a/examples/chapter_5/valid4.c
+++ b/examples/chapter_5/valid4.c
@@ -1,0 +1,7 @@
+int main(void) {
+  int a = 0;
+  int b = 3;
+  int c = 0;
+  c = (a || b) && (b > a);
+  return c;
+}

--- a/include/driver/driver.h
+++ b/include/driver/driver.h
@@ -8,6 +8,7 @@ typedef enum {
     DRIVER_STAGE_FULL = 0,   // Run full pipeline
     DRIVER_STAGE_LEX,        // Stop after lexing
     DRIVER_STAGE_PARSE,      // Stop after parsing
+    DRIVER_STAGE_VALIDATE,   // Stop after semantic validation
     DRIVER_STAGE_TACKY,      // Stop after TACKY generation
     DRIVER_STAGE_CODEGEN     // Stop after code generation (no emission)
 } DriverStage;

--- a/include/lexer/lexer.h
+++ b/include/lexer/lexer.h
@@ -18,6 +18,7 @@ typedef enum {
     TOKEN_NOT,
     TOKEN_NEGATION,
     TOKEN_DECREMENT,
+    TOKEN_ASSIGN,
     TOKEN_PLUS,
     TOKEN_STAR,
     TOKEN_SLASH,

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -1,14 +1,20 @@
 #ifndef PARSER_H
 #define PARSER_H
 
+#include <stdbool.h>
 #include "../lexer/lexer.h"
 
 typedef enum {
     AST_PROGRAM,
     AST_FUNCTION,
+    AST_BLOCK_ITEM,
+    AST_DECLARATION,
     AST_STATEMENT_RETURN,
+    AST_STATEMENT_EXPRESSION,
+    AST_STATEMENT_NULL,
     AST_EXPRESSION_CONSTANT,
-    AST_EXPRESSION_IDENTIFIER,
+    AST_EXPRESSION_VARIABLE,
+    AST_EXPRESSION_ASSIGNMENT,
     AST_EXPRESSION_NEGATE,
     AST_EXPRESSION_COMPLEMENT,
     AST_EXPRESSION_NOT,
@@ -32,6 +38,7 @@ typedef struct ASTNode {
     struct ASTNode *left;
     struct ASTNode *right;
     char *value;
+    bool owns_value;
 } ASTNode;
 
 typedef struct {
@@ -41,9 +48,6 @@ typedef struct {
 
 void parser_init(Parser *parser, Lexer *lexer);
 ASTNode *parse_program(Parser *parser);
-ASTNode *parse_function(Parser *parser);
-ASTNode *parse_statement(Parser *parser);
-ASTNode *parse_expression(Parser *parser);
 void free_ast(ASTNode *node);
 void print_ast(ASTNode *node, int depth);
 

--- a/include/semantic/semantic.h
+++ b/include/semantic/semantic.h
@@ -1,0 +1,9 @@
+#ifndef SEMANTIC_H
+#define SEMANTIC_H
+
+#include "../parser/parser.h"
+
+// Exits with a non-zero status if semantic errors are encountered.
+void resolve_variables(ASTNode *program);
+
+#endif

--- a/include/tacky/tacky.h
+++ b/include/tacky/tacky.h
@@ -1,6 +1,7 @@
 #ifndef TACKY_H
 #define TACKY_H
 
+#include <stdbool.h>
 #include "../parser/parser.h"
 
 typedef enum {
@@ -12,6 +13,7 @@ typedef struct {
     TackyValKind kind;
     int constant;      // valid if kind == TACKY_VAL_CONSTANT
     char *var_name;    // valid if kind == TACKY_VAL_VAR
+    bool owns_name;
 } TackyVal;
 
 typedef enum {

--- a/src/driver/driver.c
+++ b/src/driver/driver.c
@@ -9,10 +9,11 @@ static int has_prefix(const char *s, const char *p) {
 
 void driver_print_usage(const char *prog) {
     fprintf(stderr,
-            "Usage: %s [--lex | --parse | --tacky | --codegen] [-S] [--dump-tokens[=<path>]] [--dump-ast[=txt|dot|json] [--dump-ast-path=<path>]] [--dump-tacky[=txt|json] [--dump-tacky-path=<path>]] [--quiet] [--help|-h] <source.c>\n\n"
+            "Usage: %s [--lex | --parse | --validate | --tacky | --codegen] [-S] [--dump-tokens[=<path>]] [--dump-ast[=txt|dot|json] [--dump-ast-path=<path>]] [--dump-tacky[=txt|json] [--dump-tacky-path=<path>]] [--quiet] [--help|-h] <source.c>\n\n"
             "Stages (choose at most one):\n"
             "  --lex                   Run lexer only (no files written)\n"
             "  --parse                 Run lexer+parser (no files written)\n"
+            "  --validate              Run semantic validation (no files written)\n"
             "  --tacky                 Run up to TACKY generation (no files written)\n"
             "  --codegen               Run up to assembly IR generation (no emission)\n\n"
             "Emission:\n"
@@ -88,6 +89,13 @@ DriverOptions driver_parse_args(int argc, char **argv) {
                 exit(1);
             }
             opts.stage = DRIVER_STAGE_PARSE;
+        } else if (strcmp(arg, "--validate") == 0) {
+            if (opts.stage != DRIVER_STAGE_FULL) {
+                fprintf(stderr, "Error: Multiple stage flags provided.\n");
+                driver_print_usage(argv[0]);
+                exit(1);
+            }
+            opts.stage = DRIVER_STAGE_VALIDATE;
         } else if (strcmp(arg, "--codegen") == 0) {
             if (opts.stage != DRIVER_STAGE_FULL) {
                 fprintf(stderr, "Error: Multiple stage flags provided.\n");

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -88,9 +88,14 @@ static const char *ast_type_name(ASTNodeType t) {
     switch (t) {
         case AST_PROGRAM: return "Program";
         case AST_FUNCTION: return "Function";
+        case AST_BLOCK_ITEM: return "BlockItem";
+        case AST_DECLARATION: return "Declaration";
         case AST_STATEMENT_RETURN: return "Return";
+        case AST_STATEMENT_EXPRESSION: return "ExpressionStmt";
+        case AST_STATEMENT_NULL: return "NullStmt";
         case AST_EXPRESSION_CONSTANT: return "Constant";
-        case AST_EXPRESSION_IDENTIFIER: return "Identifier";
+        case AST_EXPRESSION_VARIABLE: return "Variable";
+        case AST_EXPRESSION_ASSIGNMENT: return "Assign";
         case AST_EXPRESSION_NEGATE: return "Negate";
         case AST_EXPRESSION_COMPLEMENT: return "Complement";
         case AST_EXPRESSION_NOT: return "Not";

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -154,7 +154,7 @@ Token lexer_next_token(Lexer *lexer) {
                 lexer->position++;
                 return make_token(TOKEN_EQUAL_EQUAL, lexer->input + start_pos, 2, start_pos);
             }
-            goto invalid_token;
+            return make_token(TOKEN_ASSIGN, lexer->input + start_pos, 1, start_pos);
         }
         default:
             goto invalid_token;

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -1,0 +1,229 @@
+#include "../../include/semantic/semantic.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SEMANTIC_ERROR(...)            \
+    do {                               \
+        fprintf(stderr, __VA_ARGS__);  \
+        fputc('\n', stderr);           \
+        exit(1);                        \
+    } while (0)
+
+typedef struct {
+    char **names;
+    char **resolved;
+    size_t count;
+    size_t capacity;
+    int next_unique;
+} VarMap;
+
+static void var_map_init(VarMap *map) {
+    map->names = NULL;
+    map->resolved = NULL;
+    map->count = 0;
+    map->capacity = 0;
+    map->next_unique = 0;
+}
+
+static void var_map_free(VarMap *map) {
+    if (!map) return;
+    for (size_t i = 0; i < map->count; i++) {
+        free(map->names[i]);
+        // Do not free map->resolved[i]; the AST owns these strings.
+    }
+    free(map->names);
+    free(map->resolved);
+}
+
+static void var_map_ensure_capacity(VarMap *map) {
+    if (map->count < map->capacity) return;
+    size_t new_cap = map->capacity ? map->capacity * 2 : 8;
+    char **new_names = (char **)realloc(map->names, new_cap * sizeof(char *));
+    char **new_resolved = (char **)realloc(map->resolved, new_cap * sizeof(char *));
+    if (!new_names || !new_resolved) {
+        free(new_names);
+        free(new_resolved);
+        SEMANTIC_ERROR("Out of memory while resolving variables");
+    }
+    map->names = new_names;
+    map->resolved = new_resolved;
+    map->capacity = new_cap;
+}
+
+static char *var_map_lookup(const VarMap *map, const char *name) {
+    for (size_t i = 0; i < map->count; i++) {
+        if (strcmp(map->names[i], name) == 0) {
+            return map->resolved[i];
+        }
+    }
+    return NULL;
+}
+
+static char *make_unique_name(const char *original, int index) {
+    size_t len = strlen(original);
+    size_t buf_sz = len + 32;
+    char *buffer = (char *)malloc(buf_sz);
+    if (!buffer) {
+        SEMANTIC_ERROR("Out of memory while generating variable name");
+    }
+    snprintf(buffer, buf_sz, "%s_%d", original, index);
+    return buffer;
+}
+
+static void var_map_add(VarMap *map, const char *name, char *resolved) {
+    if (var_map_lookup(map, name) != NULL) {
+        SEMANTIC_ERROR("Semantic Error: redeclaration of '%s'", name);
+    }
+    var_map_ensure_capacity(map);
+    map->names[map->count] = strdup(name);
+    if (!map->names[map->count]) {
+        SEMANTIC_ERROR("Out of memory while storing variable name");
+    }
+    map->resolved[map->count] = resolved;
+    map->count++;
+}
+
+static char *duplicate_owned(const char *value) {
+    char *copy = strdup(value);
+    if (!copy) {
+        SEMANTIC_ERROR("Out of memory while duplicating string");
+    }
+    return copy;
+}
+
+static void set_node_value(ASTNode *node, const char *value) {
+    if (!node) return;
+    if (node->value && node->owns_value) {
+        free(node->value);
+    }
+    if (value) {
+        node->value = duplicate_owned(value);
+        node->owns_value = true;
+    } else {
+        node->value = NULL;
+        node->owns_value = false;
+    }
+}
+
+static void set_node_value_transfer(ASTNode *node, char *value) {
+    if (!node) return;
+    if (node->value && node->owns_value) {
+        free(node->value);
+    }
+    node->value = value;
+    node->owns_value = true;
+}
+
+static void resolve_expression(ASTNode *expr, VarMap *map);
+
+static void resolve_statement(ASTNode *stmt, VarMap *map) {
+    if (!stmt) return;
+    switch (stmt->type) {
+        case AST_STATEMENT_RETURN:
+        case AST_STATEMENT_EXPRESSION:
+            resolve_expression(stmt->left, map);
+            break;
+        case AST_STATEMENT_NULL:
+            break;
+        default:
+            SEMANTIC_ERROR("Semantic Error: unexpected node type in statement");
+    }
+}
+
+static void resolve_declaration(ASTNode *decl, VarMap *map) {
+    if (!decl || decl->type != AST_DECLARATION) return;
+    if (!decl->value) {
+        SEMANTIC_ERROR("Semantic Error: declaration missing identifier");
+    }
+
+    char *resolved = make_unique_name(decl->value, map->next_unique++);
+    var_map_add(map, decl->value, resolved);
+
+    set_node_value_transfer(decl, resolved);
+
+    if (decl->left) {
+        resolve_expression(decl->left, map);
+    }
+}
+
+static void resolve_expression(ASTNode *expr, VarMap *map) {
+    if (!expr) return;
+
+    switch (expr->type) {
+        case AST_EXPRESSION_ASSIGNMENT:
+            if (!expr->left || expr->left->type != AST_EXPRESSION_VARIABLE) {
+                SEMANTIC_ERROR("Semantic Error: invalid lvalue in assignment");
+            }
+            resolve_expression(expr->left, map);
+            resolve_expression(expr->right, map);
+            break;
+        case AST_EXPRESSION_VARIABLE: {
+            if (!expr->value) {
+                SEMANTIC_ERROR("Semantic Error: unnamed variable usage");
+            }
+            char *resolved = var_map_lookup(map, expr->value);
+            if (!resolved) {
+                SEMANTIC_ERROR("Semantic Error: use of undeclared variable '%s'", expr->value);
+            }
+            set_node_value(expr, resolved);
+            break;
+        }
+        case AST_EXPRESSION_NEGATE:
+        case AST_EXPRESSION_COMPLEMENT:
+        case AST_EXPRESSION_NOT:
+            resolve_expression(expr->left, map);
+            break;
+        case AST_EXPRESSION_ADD:
+        case AST_EXPRESSION_SUBTRACT:
+        case AST_EXPRESSION_MULTIPLY:
+        case AST_EXPRESSION_DIVIDE:
+        case AST_EXPRESSION_REMAINDER:
+        case AST_EXPRESSION_EQUAL:
+        case AST_EXPRESSION_NOT_EQUAL:
+        case AST_EXPRESSION_LESS_THAN:
+        case AST_EXPRESSION_LESS_EQUAL:
+        case AST_EXPRESSION_GREATER_THAN:
+        case AST_EXPRESSION_GREATER_EQUAL:
+        case AST_EXPRESSION_LOGICAL_AND:
+        case AST_EXPRESSION_LOGICAL_OR:
+            resolve_expression(expr->left, map);
+            resolve_expression(expr->right, map);
+            break;
+        case AST_EXPRESSION_CONSTANT:
+            break;
+        default:
+            SEMANTIC_ERROR("Semantic Error: unexpected node type in expression");
+    }
+}
+
+static void resolve_block_items(ASTNode *item, VarMap *map) {
+    for (ASTNode *curr = item; curr; curr = curr->right) {
+        if (!curr || curr->type != AST_BLOCK_ITEM) {
+            SEMANTIC_ERROR("Semantic Error: invalid block item");
+        }
+        ASTNode *content = curr->left;
+        if (!content) continue;
+        if (content->type == AST_DECLARATION) {
+            resolve_declaration(content, map);
+        } else {
+            resolve_statement(content, map);
+        }
+    }
+}
+
+void resolve_variables(ASTNode *program) {
+    if (!program || program->type != AST_PROGRAM) {
+        SEMANTIC_ERROR("Semantic Error: expected program node");
+    }
+
+    ASTNode *function = program->left;
+    if (!function || function->type != AST_FUNCTION) {
+        SEMANTIC_ERROR("Semantic Error: expected function definition");
+    }
+
+    VarMap map;
+    var_map_init(&map);
+    resolve_block_items(function->left, &map);
+    var_map_free(&map);
+}

--- a/src/util/diag.c
+++ b/src/util/diag.c
@@ -27,6 +27,7 @@ const char *token_type_name(LexTokenType t) {
         case TOKEN_NOT: return "TOKEN_NOT";
         case TOKEN_NEGATION: return "TOKEN_NEGATION";
         case TOKEN_DECREMENT: return "TOKEN_DECREMENT";
+        case TOKEN_ASSIGN: return "TOKEN_ASSIGN";
         case TOKEN_PLUS: return "TOKEN_PLUS";
         case TOKEN_STAR: return "TOKEN_STAR";
         case TOKEN_SLASH: return "TOKEN_SLASH";


### PR DESCRIPTION
## Description
Chapter 5 introduces mutable state to the compiler by adding local variables, assignments, and expression statements. Implementing these features required changes across the pipeline and the addition of the project’s first semantic analysis stage.

## Frontend & AST

- The lexer now recognises the single `=` assignment operator.
- The parser builds richer ASTs: function bodies are lists of block items (declarations or statements), statements include expression and null forms, and expressions cover `Var` and `Assignment` nodes.

## Semantic Analysis

- Added a variable-resolution pass that validates declarations and uses, flags redeclarations or undeclared variables, and rewrites identifiers with unique names.
- Exposed the pass through the new driver stage flag `--validate` and integrated it ahead of TACKY generation in later stages.

## TACKY & Backend

- TACKY generation now handles variable expressions, assignments, and declaration initialisers, emitting `Copy` instructions and short-circuit logic as needed.
- Every function body appends a default `Return 0` instruction to match C’s rules for falling off the end of `main` and other functions.
- Assembly generation was updated to allocate stack slots for both temporaries and resolved locals that appear anywhere in TACKY instructions.